### PR TITLE
Fix: API requests fail with 401 Unauthorized after token expires

### DIFF
--- a/src/plugin.ht
+++ b/src/plugin.ht
@@ -27,18 +27,19 @@ class SpotifyMetadataProviderPlugin {
   var track: TrackEndpoint
   var user: UserEndpoint
   var core: CorePlugin
-  
+
   construct (){
     api = SpotifyGqlApi()
     auth = SpotifyAuthEndpoint()
 
-    album = AlbumEndpoint(api)
-    artist = ArtistEndpoint(api)
+    album = AlbumEndpoint(api, auth)
+    artist = ArtistEndpoint(api, auth)
     browse = BrowseEndpoint(api, auth)
-    playlist = PlaylistEndpoint(api)
-    search = SearchEndpoint(api)
-    track = TrackEndpoint(api)
-    user = UserEndpoint(api)
+    playlist = PlaylistEndpoint(api, auth)
+    search = SearchEndpoint(api, auth)
+    track = TrackEndpoint(api, auth)
+    user = UserEndpoint(api, auth)
+
     core = CorePlugin()
 
     auth.authStateStream.listen((event) {

--- a/src/segments/album.ht
+++ b/src/segments/album.ht
@@ -1,34 +1,50 @@
 import { SpotifyGqlApi } from '../../dependencies/hetu_spotify_gql_client/lib/assets/hetu/spotify_gql_api_client.ht'
 import { Converters } from '../converter/converter.ht'
+import { SpotifyAuthEndpoint } from "./auth.ht"
+import { SafeCaller } from "../utils/safe_caller.ht"
 
 class AlbumEndpoint {
   var client: SpotifyGqlApi
+  var auth: SpotifyAuthEndpoint
+  var caller: SafeCaller
 
-  construct (this.client)
+  construct (this.client, this.auth) {
+    caller = SafeCaller(auth)
+  }
 
   fun getAlbum(id: string) {
-    return client.album.getAlbum(id).then((album) {
-      return Converters.fullAlbums([album])[0]
+    return caller.call(() async {
+      return await client.album.getAlbum(id).then((album) {
+        return Converters.fullAlbums([album])[0]
+      })
     })
   }
 
   fun tracks(id: string, {offset: int, limit: int}) {
-    return client.album.tracks(id, offset: offset, limit: limit).then((data) {
-      return Converters.paginated(data, (items) => Converters.fullTracks(items))
+    return caller.call(() async {
+      return await client.album.tracks(id, offset: offset, limit: limit).then((data) {
+        return Converters.paginated(data, (items) => Converters.fullTracks(items))
+      })
     })
   }
 
   fun releases({offset: int, limit: int}) {
-    return client.album.releases(offset: offset, limit: limit).then((data){
-      return Converters.paginated(data, (items)=> Converters.simpleAlbums(items))
+    return caller.call(() async {
+      return await client.album.releases(offset: offset, limit: limit).then((data){
+        return Converters.paginated(data, (items)=> Converters.simpleAlbums(items))
+      })
     })
   }
 
   fun save(albumIds: List) {
-    return client.album.save(albumIds)
+    return caller.call(() async {
+      return await client.album.save(albumIds)
+    })
   }
 
   fun unsave(albumIds: List) {
-    return client.album.unsave(albumIds)
+    return caller.call(() async {
+      return await client.album.unsave(albumIds)
+    })
   }
 }

--- a/src/segments/artist.ht
+++ b/src/segments/artist.ht
@@ -1,54 +1,72 @@
 import { SpotifyGqlApi } from '../../dependencies/hetu_spotify_gql_client/lib/assets/hetu/spotify_gql_api_client.ht'
 import { Converters } from '../converter/converter.ht'
+import { SpotifyAuthEndpoint } from "./auth.ht"
+import { SafeCaller } from "../utils/safe_caller.ht"
 
 class ArtistEndpoint {
   var client: SpotifyGqlApi
+  var auth: SpotifyAuthEndpoint
+  var caller: SafeCaller
 
-  construct (this.client)
+  construct (this.client, this.auth) {
+    caller = SafeCaller(auth)
+  }
 
   fun getArtist(id: string) {
-    return client.artist.getArtist(id).then((data) {
-      return Converters.fullArtists([data])[0]
+    return caller.call(() async {
+      return await client.artist.getArtist(id).then((data) {
+        return Converters.fullArtists([data])[0]
+      })
     })
   }
 
   fun topTracks(id: string, {limit: int, offset: int}) {
-    return client.artist.topTracks(id, limit: limit, offset: offset).then((data) {
-      return {
-        total: data["tracks"].length,
-        limit: limit ?? 20,
-        nextOffset: (offset ?? 0) + (limit ?? 20),
-        hasMore: false,
-        items: Converters.fullTracks(data["tracks"])
-      }.toJson()
+    return caller.call(() {
+      return client.artist.topTracks(id, limit: limit, offset: offset).then((data) {
+        return {
+          total: data["tracks"].length,
+          limit: limit ?? 20,
+          nextOffset: (offset ?? 0) + (limit ?? 20),
+          hasMore: false,
+          items: Converters.fullTracks(data["tracks"])
+        }.toJson()
+      })
     })
   }
 
   fun albums(id: string, {offset: int, limit: int}) {
-    return client.artist.albums(id, offset: offset, limit: limit).then((data) {
-      return Converters.paginated(data, (items) => Converters.simpleAlbums(items))
+    return caller.call(() async {
+      return await client.artist.albums(id, offset: offset, limit: limit).then((data) {
+        return Converters.paginated(data, (items) => Converters.simpleAlbums(items))
+      })
     })
   }
 
   fun save(artistIds: List) {
-    return client.artist.follow(artistIds).then(() => true)
+    return caller.call(() {
+      return client.artist.follow(artistIds).then(() => true)
+    })
   }
 
   fun unsave(artistIds: List) {
-    return client.artist.unfollow(artistIds).then(() => true)
+    return caller.call(() {
+      return client.artist.unfollow(artistIds).then(() => true)
+    })
   }
 
   fun related(id: string, {offset: int, limit: int}) {
-    return client.artist.related(id).then((data) {
-      var artists = Converters.fullArtists(data["artists"])
+    return caller.call(() {
+      return client.artist.related(id).then((data) {
+        var artists = Converters.fullArtists(data["artists"])
 
-      return {
-        total: artists.length,
-        limit: limit ?? 20,
-        nextOffset: (offset ?? 0) + (limit ?? 20),
-        hasMore: false,
-        items: artists
-      }.toJson()
+        return {
+          total: artists.length,
+          limit: limit ?? 20,
+          nextOffset: (offset ?? 0) + (limit ?? 20),
+          hasMore: false,
+          items: artists
+        }.toJson()
+      })
     })
   }
 }

--- a/src/segments/browse.ht
+++ b/src/segments/browse.ht
@@ -3,72 +3,80 @@ import "module:spotube_plugin" as spotube
 import { SpotifyGqlApi } from '../../dependencies/hetu_spotify_gql_client/lib/assets/hetu/spotify_gql_api_client.ht'
 import { Converters } from '../converter/converter.ht'
 import { SpotifyAuthEndpoint } from "./auth.ht"
+import { SafeCaller } from "../utils/safe_caller.ht"
 
 var Timezone = spotube.Timezone
 
 class BrowseEndpoint {
   var client: SpotifyGqlApi
   var auth: SpotifyAuthEndpoint
+  var caller: SafeCaller
 
-  construct (this.client, this.auth)
+  construct (this.client, this.auth) {
+    caller = SafeCaller(auth)
+  }
 
   fun sections({offset: int, limit: int}) {
-    return Timezone.getLocalTimeZone().then((timeZone){
-      return client.browse.home(
-        timeZone: timeZone,
-        spTCookie: auth.credentials["cookies"].where((c)=>c["name"] == "sp_t").elementAt(0)["value"]
-        limit: limit,
-      ).then((sections){
-        return {
-          limit: limit ?? 20,
-          nextOffset: null,
-          hasMore: false,
-          total: sections.length,
-          items: sections.map((section) {            
-            var playlists = section["items"].where((item) => item["objectType"] == "Playlist").toList()
-            var albums = section["items"].where((item) => item["objectType"] == "Album").toList()
-            var artists = section["items"].where((item) => item["objectType"] == "Artist").toList()
-            
-            return {
-              id: section["id"],
-              title: section["title"],
-              externalUri: section["external_urls"]["spotify"] ?? "https://open.spotify.com/section/${section["id"]}",
-              browseMore: true,
-              items: [
-                ...Converters.simplePlaylistsFromLibraryV3(playlists),
-                ...Converters.simpleAlbums(albums),
-                ...Converters.fullArtists(artists),
-              ],
-            }.toJson()
-          }).toList()
-        }.toJson()
+    return caller.call(() {
+      return Timezone.getLocalTimeZone().then((timeZone){
+        return client.browse.home(
+          timeZone: timeZone,
+          spTCookie: auth.credentials["cookies"].where((c)=>c["name"] == "sp_t").elementAt(0)["value"],
+          limit: limit,
+        ).then((sections){
+          return {
+            limit: limit ?? 20,
+            nextOffset: null,
+            hasMore: false,
+            total: sections.length,
+            items: sections.map((section) {
+              var playlists = section["items"].where((item) => item["objectType"] == "Playlist").toList()
+              var albums = section["items"].where((item) => item["objectType"] == "Album").toList()
+              var artists = section["items"].where((item) => item["objectType"] == "Artist").toList()
+
+              return {
+                id: section["id"],
+                title: section["title"],
+                externalUri: section["external_urls"]["spotify"] ?? "https://open.spotify.com/section/${section["id"]}",
+                browseMore: true,
+                items: [
+                  ...Converters.simplePlaylistsFromLibraryV3(playlists),
+                  ...Converters.simpleAlbums(albums),
+                  ...Converters.fullArtists(artists),
+                ],
+              }.toJson()
+            }).toList()
+          }.toJson()
+        })
       })
     })
   }
 
   fun sectionItems(id: string, {offset: int, limit: int}) {
-    return Timezone.getLocalTimeZone().then((timeZone) {
-      return client.browse.homeSection(
-        id, 
-        timeZone: timeZone,
-        spTCookie: auth.credentials["cookies"].where((c)=>c["name"] == "sp_t").elementAt(0)["value"],
-        offset: offset,
-        limit: limit,
-      ).then((section){
-        return Converters.paginated(
-          section,
-          (items) {
-            var playlists = section["items"].where((item) => item["objectType"] == "Playlist").toList()
-            var albums = section["items"].where((item) => item["objectType"] == "Album").toList()
-            var artists = section["items"].where((item) => item["objectType"] == "Artist").toList()
+    return caller.call(() {
+      return Timezone.getLocalTimeZone().then((timeZone) {
+        return client.browse.homeSection(
+          id,
+          timeZone: timeZone,
+          spTCookie: auth.credentials["cookies"].where((c)=>c["name"] == "sp_t").elementAt(0)["value"],
+          offset: offset,
+          limit: limit,
+        ).then((section){
+          return Converters.paginated(
+            section,
+            (items) {
+              var playlists = section["items"].where((item) => item["objectType"] == "Playlist").toList()
+              var albums = section["items"].where((item) => item["objectType"] == "Album").toList()
+              var artists = section["items"].where((item) => item["objectType"] == "Artist").toList()
 
-            return [
-                ...Converters.simplePlaylistsFromLibraryV3(playlists),
-                ...Converters.simpleAlbums(albums),
-                ...Converters.fullArtists(artists),
-              ]
-          }
-        )
+              return [
+                  ...Converters.simplePlaylistsFromLibraryV3(playlists),
+                  ...Converters.simpleAlbums(albums),
+                  ...Converters.fullArtists(artists),
+                ]
+            }
+          )
+        })
       })
     })
   }

--- a/src/segments/playlist.ht
+++ b/src/segments/playlist.ht
@@ -1,29 +1,39 @@
 import { SpotifyGqlApi } from '../../dependencies/hetu_spotify_gql_client/lib/assets/hetu/spotify_gql_api_client.ht'
 import { Converters } from '../converter/converter.ht'
+import { SpotifyAuthEndpoint } from "./auth.ht"
+import { SafeCaller } from "../utils/safe_caller.ht"
 
 class PlaylistEndpoint {
   var client: SpotifyGqlApi
+  var auth: SpotifyAuthEndpoint
+  var caller: SafeCaller
 
-  construct (this.client)
+  construct (this.client, this.auth) {
+    caller = SafeCaller(auth)
+  }
 
   fun getPlaylist(id: string) {
-    return client.playlist.getPlaylist(id).then((data) {
-      return Converters.fullPlaylists([data])[0]
+    return caller.call(() async {
+      return await client.playlist.getPlaylist(id).then((data) {
+        return Converters.fullPlaylists([data])[0]
+      })
     })
   }
 
   fun tracks(id: string, { offset: int, limit: int }) {
-    return client.playlist.tracks(id, offset: offset, limit: limit).then((data) {
-      var paginated = Converters.paginated(
-        data, 
-        (items) => Converters.fullTracks(items)
-      )
+    return caller.call(() async {
+      return await client.playlist.tracks(id, offset: offset, limit: limit).then((data) {
+        var paginated = Converters.paginated(
+          data,
+          (items) => Converters.fullTracks(items)
+        )
 
-      // Spotify playlists can contain local tracks which do not have an ID and cannot be played
-      // We filter them out here to avoid issues in the client
-      paginated["items"] = paginated["items"].where((item) => item != null && item["id"] != null).toList()
+        // Spotify playlists can contain local tracks which do not have an ID and cannot be played
+        // We filter them out here to avoid issues in the client
+        paginated["items"] = paginated["items"].where((item) => item != null && item["id"] != null).toList()
 
-      return paginated
+        return paginated
+      })
     })
   }
 
@@ -33,14 +43,16 @@ class PlaylistEndpoint {
     public: bool,
     collaborative: bool
   }) {
-    return client.playlist.create(
-      userId,
-      name: name,
-      description: description,
-      public: public,
-      collaborative: collaborative
-    ).then((data) {
-      return Converters.fullPlaylists([data])[0]
+    return caller.call(() async {
+      return await client.playlist.create(
+        userId,
+        name: name,
+        description: description,
+        public: public,
+        collaborative: collaborative
+      ).then((data) {
+        return Converters.fullPlaylists([data])[0]
+      })
     })
   }
 
@@ -50,41 +62,53 @@ class PlaylistEndpoint {
     public: bool,
     collaborative: bool
   }) {
-    return client.playlist.update(
-      playlistId,
-      name: name,
-      description: description,
-      public: public,
-      collaborative: collaborative
-    )
+    return caller.call(() async {
+      return await client.playlist.update(
+        playlistId,
+        name: name,
+        description: description,
+        public: public,
+        collaborative: collaborative
+      )
+    })
   }
 
   fun deletePlaylist(playlistId: string) {
-    return this.unsave(playlistId)
+    return caller.call(() async {
+      return await this.unsave(playlistId)
+    })
   }
 
   fun addTracks(playlistId: string, { trackIds: List, position: int }) {
-    return client.playlist.addTracks(
-      playlistId,
-      uris: trackIds.map((id)=>"spotify:track:${id}").toList(),
-      position: position
-    )
+    return caller.call(() async {
+      return await client.playlist.addTracks(
+        playlistId,
+        uris: trackIds.map((id)=>"spotify:track:${id}").toList(),
+        position: position
+      )
+    })
   }
 
 
   fun removeTracks(playlistId: string, { trackIds: List }) {
-    return client.playlist.removeTracks(
-      playlistId, 
-      uris: trackIds.map((id)=>"spotify:track:${id}").toList()
-    )
+    return caller.call(() {
+      return client.playlist.removeTracks(
+        playlistId,
+        uris: trackIds.map((id)=>"spotify:track:${id}").toList()
+      )
+    })
   }
 
   fun save(playlistId: string) {
-    return client.playlist.follow(playlistId)
+    return caller.call(() async {
+      return await client.playlist.follow(playlistId)
+    })
   }
 
   fun unsave(playlistId: string) {
-    return client.playlist.unfollow(playlistId)
+    return caller.call(() async {
+      return await client.playlist.unfollow(playlistId)
+    })
   }
 }
 

--- a/src/segments/search.ht
+++ b/src/segments/search.ht
@@ -1,10 +1,16 @@
 import { SpotifyGqlApi } from '../../dependencies/hetu_spotify_gql_client/lib/assets/hetu/spotify_gql_api_client.ht'
 import { Converters } from '../converter/converter.ht'
+import { SpotifyAuthEndpoint } from "./auth.ht"
+import { SafeCaller } from "../utils/safe_caller.ht"
 
 class SearchEndpoint {
   var client: SpotifyGqlApi
+  var auth: SpotifyAuthEndpoint
+  var caller: SafeCaller
 
-  construct (this.client)
+  construct (this.client, this.auth) {
+    caller = SafeCaller(auth)
+  }
 
   get chips -> List { // Set<string>
     // can be tracks, playlists, artists, albums and all
@@ -12,51 +18,61 @@ class SearchEndpoint {
   }
 
   fun all(query: string) {
-    return client.search.all(
-      query,
-      limit: 20
-    ).then((data){
-      var result = {
-        artists: Converters.simpleArtists(data["artists"]),
-        albums: Converters.simpleAlbums(data["albums"]),
-        tracks: Converters.fullTracks(data["tracks"]),
-        playlists: Converters.simplePlaylistsFromLibraryV3(data["playlists"]),
-      }.toJson()
+    return caller.call(() async {
+      return await client.search.all(
+        query,
+        limit: 20
+      ).then((data){
+        var result = {
+          artists: Converters.simpleArtists(data["artists"]),
+          albums: Converters.simpleAlbums(data["albums"]),
+          tracks: Converters.fullTracks(data["tracks"]),
+          playlists: Converters.simplePlaylistsFromLibraryV3(data["playlists"]),
+        }.toJson()
 
-      return result
+        return result
+      })
     })
   }
 
   fun albums(query: string, {offset: int, limit: int}) {
-    return client.search.albums(
-      query,
-      offset: offset,
-      limit: limit
-    ).then((data) => Converters.paginated(data, (items) => Converters.simpleAlbums(items)))
+    return caller.call(() async {
+      return await client.search.albums(
+        query,
+        offset: offset,
+        limit: limit
+      ).then((data) => Converters.paginated(data, (items) => Converters.simpleAlbums(items)))
+    })
   }
 
   fun artists(query: string, {offset: int, limit: int}) {
-    return client.search.artists(
-      query,
-      offset: offset,
-      limit: limit
-    ).then((data) => Converters.paginated(data, (items) => Converters.simpleArtists(items)))
+    return caller.call(() async {
+      return await client.search.artists(
+        query,
+        offset: offset,
+        limit: limit
+      ).then((data) => Converters.paginated(data, (items) => Converters.simpleArtists(items)))
+    })
   }
 
   fun tracks(query: string, {offset: int, limit: int}) {
-    return client.search.tracks(
-      query,
-      offset: offset,
-      limit: limit
-    ).then((data) => Converters.paginated(data, (items) => Converters.fullTracks(items)))
+    return caller.call(() async {
+      return await client.search.tracks(
+        query,
+        offset: offset,
+        limit: limit
+      ).then((data) => Converters.paginated(data, (items) => Converters.fullTracks(items)))
+    })
   }
 
   fun playlists(query: string, {offset: int, limit: int}) {
-    return client.search.playlists(
-      query,
-      offset: offset,
-      limit: limit
-    ).then((data) => Converters.paginated(data, (items) => Converters.simplePlaylistsFromLibraryV3(items)))
+    return caller.call(() async {
+      return await client.search.playlists(
+        query,
+        offset: offset,
+        limit: limit
+      ).then((data) => Converters.paginated(data, (items) => Converters.simplePlaylistsFromLibraryV3(items)))
+    })
   }
 }
 

--- a/src/segments/track.ht
+++ b/src/segments/track.ht
@@ -1,43 +1,57 @@
 import { SpotifyGqlApi } from '../../dependencies/hetu_spotify_gql_client/lib/assets/hetu/spotify_gql_api_client.ht'
 import { Converters } from '../converter/converter.ht'
+import { SpotifyAuthEndpoint } from "./auth.ht"
+import { SafeCaller } from "../utils/safe_caller.ht"
 
 class TrackEndpoint {
   var client: SpotifyGqlApi
+  var auth: SpotifyAuthEndpoint
+  var caller: SafeCaller
 
-  construct (this.client)
+  construct (this.client, this.auth) {
+    caller = SafeCaller(auth)
+  }
 
   fun getTrack(id: string) {
-    return client.track.getTrack(id).then((data) {
-      return Converters.fullTracks([data])[0]
+    return caller.call(() async {
+      return await client.track.getTrack(id).then((data) {
+        return Converters.fullTracks([data])[0]
+      })
     })
   }
 
   fun save(trackIds: List) async {
-    await client.track.save(trackIds)
-    return true
+    return caller.call(() async {
+      await client.track.save(trackIds)
+      return true
+    })
   }
 
   fun unsave(trackIds: List) async {
-    await client.track.unsave(trackIds)
-    return true
+    return caller.call(() async {
+      await client.track.unsave(trackIds)
+      return true
+    })
   }
 
   fun radio(trackId: string) {
-    return client.track.getTrack(trackId).then((data){
-      var query = "${data['name']} Radio"
-      return client.search.playlists(query, limit: 20).then((data) {
-        var playlists = data["items"];
-        var radioPlaylist = playlists.firstWhere((playlist) => playlist["name"] == query, orElse: () => null);
-        return client.playlist.tracks(radioPlaylist["id"], offset: 0, limit: 50)
-          .then((data) {
-            var tracks = data["items"].map((item){
-              item["track"]["available_markets"] = null
-              return item["track"]
-            })
-            .toList()
+    return caller.call(() async {
+      return await client.track.getTrack(trackId).then((data){
+        var query = "${data['name']} Radio"
+        return client.search.playlists(query, limit: 20).then((data) {
+          var playlists = data["items"];
+          var radioPlaylist = playlists.firstWhere((playlist) => playlist["name"] == query, orElse: () => null);
+          return client.playlist.tracks(radioPlaylist["id"], offset: 0, limit: 50)
+            .then((data) {
+              var tracks = data["items"].map((item){
+                item["track"]["available_markets"] = null
+                return item["track"]
+              })
+              .toList()
 
-            return Converters.fullTracks(tracks)
-          });
+              return Converters.fullTracks(tracks)
+            });
+        })
       })
     })
   }

--- a/src/segments/user.ht
+++ b/src/segments/user.ht
@@ -1,64 +1,88 @@
 import { SpotifyGqlApi } from '../../dependencies/hetu_spotify_gql_client/lib/assets/hetu/spotify_gql_api_client.ht'
 import { Converters } from '../converter/converter.ht'
+import { SpotifyAuthEndpoint } from "./auth.ht"
+import { SafeCaller } from "../utils/safe_caller.ht"
 
 class UserEndpoint {
   var client: SpotifyGqlApi
+  var auth: SpotifyAuthEndpoint
+  var caller: SafeCaller
 
-  construct (this.client)
-  
+  construct (this.client, this.auth) {
+    caller = SafeCaller(auth)
+  }
+
   fun me() {
-    return client.user.me().then((data){
-      return Converters.simpleUser(data)
+    return caller.call(() async {
+      return await client.user.me().then((data){
+        return Converters.simpleUser(data)
+      })
     })
   }
 
   fun savedTracks({ offset: int, limit: int }) {
-    return client.user.savedTracks(offset: offset, limit: limit).then(
-      (data) => Converters.paginated(data, (items) => Converters.fullTracks(items))
-    )
+    return caller.call(() async {
+      return await client.user.savedTracks(offset: offset, limit: limit).then(
+        (data) => Converters.paginated(data, (items) => Converters.fullTracks(items))
+      )
+    })
   }
 
   fun savedPlaylists({ offset: int, limit: int }) {
-    return client.user.savedPlaylists(offset: offset, limit: limit).then((data){           
-      return Converters.paginated(
-        data, 
-        (items) => Converters.simplePlaylistsFromLibraryV3(data["items"])
-      )
+    return caller.call(() async {
+      return await client.user.savedPlaylists(offset: offset, limit: limit).then((data){
+        return Converters.paginated(
+          data,
+          (items) => Converters.simplePlaylistsFromLibraryV3(data["items"])
+        )
+      })
     })
   }
 
   fun savedAlbums({ offset: int, limit: int }) {
-    return client.user.savedAlbums(offset: offset, limit: limit).then((data){
-      return Converters.paginated(
-        data, 
-        (items) => Converters.simpleAlbums(items)
-      )
+    return caller.call(() async {
+      return await client.user.savedAlbums(offset: offset, limit: limit).then((data){
+        return Converters.paginated(
+          data,
+          (items) => Converters.simpleAlbums(items)
+        )
+      })
     })
   }
 
   fun savedArtists({ offset: int, limit: int }) {
-    return client.user.savedArtists(offset: offset, limit: limit).then((data){
-      return Converters.paginated(
-        data, 
-        (items) => Converters.fullArtists(items)
-      )
+    return caller.call(() async {
+      return await client.user.savedArtists(offset: offset, limit: limit).then((data){
+        return Converters.paginated(
+          data,
+          (items) => Converters.fullArtists(items)
+        )
+      })
     })
   }
 
   fun isSavedPlaylist(playlistId: string) { // Future<bool>
-    return client.user.isPlaylistSaved(playlistId)
+    return caller.call(() async {
+      return await client.user.isPlaylistSaved(playlistId)
+    })
   }
 
   fun isSavedTracks(trackIds: List) { // Future<List<bool>>
-    return client.user.isTracksSaved(trackIds)
+    return caller.call(() async {
+      return await client.user.isTracksSaved(trackIds)
+    })
   }
 
   fun isSavedAlbums(albumIds: List) { // Future<List<bool>>
-    return client.user.isInLibrary(albumIds, itemType: "album")
+    return caller.call(() {
+      return client.user.isInLibrary(albumIds, itemType: "album")
+    })
   }
 
   fun isSavedArtists(artistIds: List) { // Future<List<bool>>
-    return client.user.isInLibrary(artistIds, itemType: "artist")
+    return caller.call(() {
+      return client.user.isInLibrary(artistIds, itemType: "artist")
+    })
   }
 }
 

--- a/src/utils/safe_caller.ht
+++ b/src/utils/safe_caller.ht
@@ -1,0 +1,31 @@
+import { SpotifyAuthEndpoint } from "../segments/auth.ht"
+
+class SafeCaller {
+  var auth: SpotifyAuthEndpoint
+
+  construct (this.auth)
+
+  fun call(callback) {
+    return callback().then(
+      (value) {
+        return value
+      },
+      catchError: (e) {
+        var errStr = e.toString()
+        if (errStr.contains("401") || errStr.contains("Unauthorized")) {
+          print("[SafeCaller] Token expired (401). Refreshing credentials...")
+
+          return auth.refreshCredentials().then((_) {
+            print("[SafeCaller] Token refreshed. Retrying request...")
+
+            return callback()
+          })
+        } else {
+          throw e
+        }
+      }
+    )
+  }
+}
+
+export { SafeCaller }


### PR DESCRIPTION
**Title:** `Fix: API requests fail with 401 Unauthorized after token expires`

### Summary
This pull request introduces an automatic token refresh mechanism to fix a critical authentication bug. Currently, when a Spotify access token expires, all subsequent API requests fail with a `401 Unauthorized` error, forcing the user to manually log out and log back in.

This is especially noticeable when opening Spotify links from external applications (e.g., `https://open.spotify.com/track/...`) using the method mentioned below, as the app opens but fails to load the track data, showing a placeholder screen.

### The Problem
The plugin's API endpoints (for tracks, artists, etc.) did not handle the `401 Unauthorized` error. When the token expired, they would throw an exception instead of triggering the existing `refreshCredentials()` function in the `auth` module.

### The Solution
The fix is architecturally centralized, ensuring all API calls are resilient to token expiry:

1.  **Centralized Error Handling (`SafeCaller` utility):** A new utility class, `SafeCaller`, has been created. It wraps every API call in a function that uses Hetu's `.then(catchError:)` pattern. If a `401` error is detected, it automatically calls `auth.refreshCredentials()` and retries the original request with the new, valid token.

2.  **Dependency Injection:** The main `plugin.ht` now injects the `auth` module into every endpoint, making the authentication context available wherever needed.

3.  **Refactored Endpoints:** All API-calling functions have been updated to use the `SafeCaller`, making the retry logic consistent across the entire plugin.

This ensures a seamless user experience, as token refreshes happen automatically in the background without interrupting the user.

### Context for External Link Handling
This fix is crucial for users who rely on opening Spotify links via third-party tools (like **URLCheck** on Android) that map `https://open.spotify.com/...` URLs to Spotube's internal deep links (e.g., `spotube://spotify/track/TRACK_ID`). Without this patch, this core functionality becomes unreliable as soon as the session token expires.

This PR makes that workflow robust and reliable again.

This may be related to these:
https://github.com/KRTirtho/spotube/issues/2818
#36 
#27 